### PR TITLE
[codex] add character update endpoint

### DIFF
--- a/DataAccess/characters.js
+++ b/DataAccess/characters.js
@@ -52,7 +52,7 @@ async function prepareCharacterDocument(owner, payload, existingDocument = {}) {
         baseDocument.baseAbilityScores = inferredBaseAbilityScores;
     }
 
-    if (payload.maxHp === undefined && existingDocument.maxHp === undefined) {
+    if (payload.maxHp === undefined) {
         delete baseDocument.maxHp;
     }
 
@@ -104,6 +104,52 @@ async function createCharacter(owner, payload) {
     });
 }
 
+async function updateCharacterForEmail(characterId, email, payload) {
+    if (!ObjectId.isValid(characterId)) {
+        return null;
+    }
+
+    const db = await getDb();
+    const storedCharacter = await db.collection('Character').findOne({
+        _id: new ObjectId(characterId),
+        email
+    });
+
+    if (!storedCharacter) {
+        return null;
+    }
+
+    const owner = {
+        email: storedCharacter.email,
+        userName: storedCharacter.userName
+    };
+    const character = await prepareCharacterDocument(owner, payload, storedCharacter);
+    const updatedCharacter = {
+        ...character,
+        createdAt: storedCharacter.createdAt || character.createdAt,
+        updatedAt: new Date().toISOString()
+    };
+
+    try {
+        await db.collection('Character').replaceOne(
+            { _id: storedCharacter._id, email },
+            updatedCharacter
+        );
+    } catch (error) {
+        if (isDuplicateKeyError(error)) {
+            error.statusCode = 409;
+            error.message = 'Character name already exists for this user';
+        }
+
+        throw error;
+    }
+
+    return serializeCharacter({
+        ...updatedCharacter,
+        _id: storedCharacter._id
+    });
+}
+
 async function getCharacterByIdForEmail(characterId, email) {
     if (!ObjectId.isValid(characterId)) {
         return null;
@@ -124,7 +170,7 @@ async function getCharacterByIdForEmail(characterId, email) {
         userName: storedCharacter.userName
     };
 
-    const character = await prepareCharacterDocument(owner, storedCharacter, storedCharacter);
+    const character = await prepareCharacterDocument(owner, {}, storedCharacter);
     return serializeCharacter({ ...character, _id: storedCharacter._id, createdAt: storedCharacter.createdAt });
 }
 
@@ -132,5 +178,6 @@ module.exports = {
     createCharacter,
     getCharacterByIdForEmail,
     listCharacterSummariesByEmail,
-    prepareCharacterDocument
+    prepareCharacterDocument,
+    updateCharacterForEmail
 };

--- a/routes/character/character.js
+++ b/routes/character/character.js
@@ -3,7 +3,8 @@ const express = require('express');
 const {
     createCharacter,
     getCharacterByIdForEmail,
-    listCharacterSummariesByEmail
+    listCharacterSummariesByEmail,
+    updateCharacterForEmail
 } = require('../../DataAccess/characters');
 const { authenticate } = require('../../middleware/authenticate');
 const { asyncHandler } = require('../../middleware/asyncHandler');
@@ -21,48 +22,85 @@ function isAbilityScoreObject(value) {
         .every((key) => Number.isFinite(Number(value[key])));
 }
 
+function hasOwn(object, key) {
+    return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function validateCharacterPayload(payload, { partial = false } = {}) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return 'Character payload must be an object';
+    }
+
+    if (!partial || hasOwn(payload, 'characterName')) {
+        const characterName = typeof payload.characterName === 'string'
+            ? payload.characterName.trim()
+            : '';
+
+        if (!characterName) {
+            return 'characterName is required';
+        }
+    }
+
+    if (!partial || hasOwn(payload, 'raceId')) {
+        const raceId = typeof payload.raceId === 'string' ? payload.raceId.trim() : '';
+
+        if (!raceId) {
+            return 'raceId is required';
+        }
+    }
+
+    if (!partial || hasOwn(payload, 'classId')) {
+        const classId = typeof payload.classId === 'string' ? payload.classId.trim() : '';
+
+        if (!classId) {
+            return 'classId is required';
+        }
+    }
+
+    if (!partial || hasOwn(payload, 'level')) {
+        const level = Number(payload.level);
+
+        if (!Number.isInteger(level) || level < 1 || level > 20) {
+            return 'level must be an integer between 1 and 20';
+        }
+    }
+
+    if (hasOwn(payload, 'baseAbilityScores') && !isAbilityScoreObject(payload.baseAbilityScores)) {
+        return 'baseAbilityScores must include numeric str, dex, con, int, wis, and cha values';
+    }
+
+    return null;
+}
+
 router.post('/', asyncHandler(async (req, res) => {
-    if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
-        res.status(400).json({ error: 'Character payload must be an object' });
-        return;
-    }
+    const validationError = validateCharacterPayload(req.body);
 
-    const characterName = typeof req.body.characterName === 'string'
-        ? req.body.characterName.trim()
-        : '';
-
-    if (!characterName) {
-        res.status(400).json({ error: 'characterName is required' });
-        return;
-    }
-
-    const raceId = typeof req.body.raceId === 'string' ? req.body.raceId.trim() : '';
-    const classId = typeof req.body.classId === 'string' ? req.body.classId.trim() : '';
-    const level = Number(req.body.level);
-
-    if (!raceId) {
-        res.status(400).json({ error: 'raceId is required' });
-        return;
-    }
-
-    if (!classId) {
-        res.status(400).json({ error: 'classId is required' });
-        return;
-    }
-
-    if (!Number.isInteger(level) || level < 1 || level > 20) {
-        res.status(400).json({ error: 'level must be an integer between 1 and 20' });
-        return;
-    }
-
-    if (req.body.baseAbilityScores && !isAbilityScoreObject(req.body.baseAbilityScores)) {
-        res.status(400).json({ error: 'baseAbilityScores must include numeric str, dex, con, int, wis, and cha values' });
+    if (validationError) {
+        res.status(400).json({ error: validationError });
         return;
     }
 
     const character = await createCharacter(req.user, req.body);
 
     res.status(201).json({ character });
+}));
+
+router.put('/:characterId', asyncHandler(async (req, res) => {
+    const validationError = validateCharacterPayload(req.body, { partial: true });
+
+    if (validationError) {
+        res.status(400).json({ error: validationError });
+        return;
+    }
+
+    const character = await updateCharacterForEmail(req.params.characterId, req.user.email, req.body);
+
+    if (!character) {
+        res.status(404).json({ error: 'Character not found' });
+        return;
+    }
+
+    res.json({ character });
 }));
 
 router.get('/', asyncHandler(async (req, res) => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -298,6 +298,97 @@ test('GET /player/:characterId returns an owned character by id with spell data'
     assert.ok(response.body.character.featureIds.includes('sculpt-spells'));
 });
 
+test('PUT /player/:characterId updates an owned character and re-derives dependent stats', async () => {
+    await seedUser();
+    const token = await signIn();
+
+    const createResponse = await request(app)
+        .post('/player')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+            characterName: 'Brim',
+            raceId: 'high-elf',
+            classId: 'wizard',
+            subclassId: 'evocation',
+            level: 3,
+            baseAbilityScores: {
+                str: 8,
+                dex: 14,
+                con: 13,
+                int: 18,
+                wis: 12,
+                cha: 10
+            },
+            cantripIds: ['fire-bolt', 'mage-hand'],
+            knownSpellIds: ['magic-missile', 'shield', 'scorching-ray'],
+            preparedSpellIds: ['magic-missile', 'shield', 'scorching-ray']
+        });
+
+    const response = await request(app)
+        .put(`/player/${createResponse.body.character._id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+            level: 5,
+            characterName: 'Archmage Brim',
+            baseAbilityScores: {
+                str: 8,
+                dex: 14,
+                con: 13,
+                int: 20,
+                wis: 12,
+                cha: 10
+            },
+            knownSpellIds: ['magic-missile', 'shield', 'scorching-ray', 'fireball'],
+            preparedSpellIds: ['magic-missile', 'shield', 'fireball']
+        });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body.character.characterName, 'Archmage Brim');
+    assert.equal(response.body.character.level, 5);
+    assert.equal(response.body.character.proficiencyBonus, 3);
+    assert.equal(response.body.character.abilityScores.int, 21);
+    assert.equal(response.body.character.spellSaveDC, 16);
+    assert.equal(response.body.character.spellAttackBonus, 8);
+    assert.equal(response.body.character.maxHp, 27);
+    assert.equal(response.body.character.spellSlots.level_3.slotTotal, 2);
+    assert.ok(response.body.character.availableSpellIds.includes('fireball'));
+    assert.ok(response.body.character.featureIds.includes('third-level-spells'));
+});
+
+test('PUT /player/:characterId validates partial character updates', async () => {
+    await seedUser();
+    const token = await signIn();
+
+    const createResponse = await request(app)
+        .post('/player')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+            characterName: 'Brim',
+            raceId: 'high-elf',
+            classId: 'wizard',
+            subclassId: 'evocation',
+            level: 5,
+            baseAbilityScores: {
+                str: 8,
+                dex: 14,
+                con: 13,
+                int: 18,
+                wis: 12,
+                cha: 10
+            }
+        });
+
+    const response = await request(app)
+        .put(`/player/${createResponse.body.character._id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+            level: 21
+        });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.error, 'level must be an integer between 1 and 20');
+});
+
 test('POST /player validates required compendium fields', async () => {
     await seedUser();
     const token = await signIn();


### PR DESCRIPTION
## What changed
- add `PUT /player/:characterId` for owned character updates
- re-derive dependent stats when a character changes
- add API coverage for update and validation flows

## Why
The client needs a safe update path for level-up and future sheet editing without trusting stale derived fields.

## Impact
Character updates can now refresh HP, spell slots, features, and other derived fields from the backend.

## Validation
- `npm.cmd test`
